### PR TITLE
EPROD-421 used virtual_canister_call in ic_client

### DIFF
--- a/src/evmc-client/Cargo.toml
+++ b/src/evmc-client/Cargo.toml
@@ -20,6 +20,7 @@ ic-agent-client = ["dep:ic-agent"]
 [dependencies]
 candid = { workspace = true }
 did = { path = "../did" }
+ic-canister = { workspace = true }
 ic-exports = { workspace = true }
 serde_json = { workspace = true }
 serde = { workspace = true }


### PR DESCRIPTION
# Issue ticket

Issue ticket link: <>

## Checklist before requesting a review

### Code conventions

- [x] I have performed a self-review of my code
- [x] Every new function is documented
- [x] Object names are auto explicative

### Security

- [x] The PR does not break APIs backward compatibility
- [x] The PR does not break the stable storage backward compatibility

### Testing

- [x] Every function is properly unit tested
- [x] I have added integration tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] IC endpoints are always tested through the `canister_call!` macro
