### PR TITLE
chore: remove ethers-core fork

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ clap = { version = "4", features = ["derive"] }
 derive_more = "0.99"
 env_logger = { version = "0.10.0", default-features = false }
 ethereum-types = "0.14"
-ethers-core = { git = "https://github.com/bitfinity-network/ethers-rs", default-features = false, package = "ethers-core", branch = "evmc_fork" }
+ethers-core = "2.0"
 hash-db = "0.16"
 hex = "0.4"
 ic-canister = { git = "https://github.com/bitfinity-network/canister-sdk", package = "ic-canister", tag = "v0.5.x" }

--- a/src/did/src/block.rs
+++ b/src/did/src/block.rs
@@ -375,6 +375,9 @@ impl<D, T: From<D>> From<Block<D>> for ethers_core::types::Block<T> {
             nonce: Some(block.nonce.into()),
             base_fee_per_gas: block.base_fee_per_gas.map(Into::into),
             other: ethers_core::types::OtherFields::default(),
+            // We can leave it empty because we don't need it for our fork
+            withdrawals_root: None,
+            withdrawals: None,
         }
     }
 }


### PR DESCRIPTION
# Issue ticket

We can remove the ethers-core fork as they have remove the `js` feature from the getrandom crate which was conflicting with our wasm compilation

Link to the PR : https://github.com/gakonst/ethers-rs/pull/2433

Issue ticket link: <>

## Checklist before requesting a review

### Code conventions

- [x] I have performed a self-review of my code
- [x] Every new function is documented
- [x] Object names are auto explicative

### Security

- [x] The PR does not break APIs backward compatibility
- [x] The PR does not break the stable storage backward compatibility

### Testing

- [x] Every function is properly unit tested
- [x] I have added integration tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] IC endpoints are always tested through the `canister_call!` macro
