### PR TITLE
EPROD 582 fix logging issue after upgrade in all affected canisters

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ include = ["src/**/*", "LICENSE", "README.md"]
 license = "MIT"
 name = "bitfinity-evm-sdk"
 repository = "https://github.com/bitfinity-network/bitfinity-evm-sdk"
-version = "0.6.1"
+version = "0.6.2"
 
 [workspace.dependencies]
 anyhow = "1.0"

--- a/src/evm-canister-client/src/client.rs
+++ b/src/evm-canister-client/src/client.rs
@@ -468,6 +468,19 @@ impl<C: CanisterClient> EvmCanisterClient<C> {
             .await
     }
 
+    /// Updates the runtime configuration of the logger with a new filter in the same form as the `RUST_LOG`
+    /// environment variable.
+    /// Example of valid filters:
+    /// - info
+    /// - debug,crate1::mod1=error,crate1::mod2,crate2=debug
+    ///
+    /// # Arguments
+    ///
+    /// * `filter` - The new filter.
+    pub async fn set_logger_filter(&self, filter: &str) -> CanisterClientResult<Result<()>> {
+        self.client.update("set_logger_filter", (filter,)).await
+    }
+
     /// Disable or enable the EVM. This function requires admin permissions.
     ///
     /// # Arguments


### PR DESCRIPTION
# EPROD 582 fix logging issue after upgrade in all affected canisters

Issue ticket link: <https://infinityswap.atlassian.net/browse/EPROD-582>

## Checklist before requesting a review

### Code conventions

- [ ] I have performed a self-review of my code
- [ ] Every new function is documented
- [ ] Object names are auto explicative

### Security

- [ ] The PR does not break APIs backward compatibility
- [ ] The PR does not break the stable storage backward compatibility

### Testing

- [ ] Every function is properly unit tested
- [ ] I have added integration tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] IC endpoints are always tested through the `canister_call!` macro
