### PR TITLE
Use did types in evm-block-extractor database

### DIFF
--- a/src/did/src/block.rs
+++ b/src/did/src/block.rs
@@ -109,6 +109,35 @@ impl Block<H256> {
             base_fee_per_gas: None,
         }
     }
+
+        /// Converts this block that only holds transaction hashes into a full block with `Transaction`
+        pub fn into_full_block(self, transactions: Vec<Transaction>) -> Block<Transaction> {
+                Block {
+                    hash: self.hash,
+                    parent_hash: self.parent_hash,
+                    uncles_hash: self.uncles_hash,
+                    author: self.author,
+                    state_root: self.state_root,
+                    transactions_root: self.transactions_root,
+                    receipts_root: self.receipts_root,
+                    number: self.number,
+                    gas_used: self.gas_used,
+                    gas_limit: self.gas_limit,
+                    extra_data: self.extra_data,
+                    logs_bloom: self.logs_bloom,
+                    timestamp: self.timestamp,
+                    difficulty: self.difficulty,
+                    total_difficulty: self.total_difficulty,
+                    seal_fields: self.seal_fields,
+                    uncles: self.uncles,
+                    size: self.size,
+                    mix_hash: self.mix_hash,
+                    nonce: self.nonce,
+                    base_fee_per_gas: self.base_fee_per_gas,
+                    transactions,
+                }
+            }
+    
 }
 
 impl Default for Block<H256> {
@@ -467,6 +496,10 @@ impl ExeResult {
     }
 }
 
+// impl From<ethers_core::types::Exe> for Block<T> {
+
+// }
+
 impl Storable for ExeResult {
     const BOUND: Bound = Bound::Unbounded;
 
@@ -803,4 +836,58 @@ mod test {
             42u64.into(),
         )));
     }
+
+    #[test]
+    fn test_block_into_full_block() {
+
+        let transactions = vec![
+            create_transaction(
+                Some(U256::from(rand::random::<u64>())),
+                1,
+            ),
+            create_transaction(
+                Some(U256::from(rand::random::<u64>())),
+                2,
+            ),
+            create_transaction(
+                Some(U256::from(rand::random::<u64>())),
+                3,
+            )
+        ];
+
+        let tx_hashes = transactions.iter().map(|tx| tx.hash.clone()).collect::<Vec<_>>();
+
+        let block = Block::<H256> {
+            author: ethereum_types::H160::random().into(),
+            number: U64::from(rand::random::<u64>()),
+            logs_bloom: Bloom(ethereum_types::Bloom::from_slice(&[4u8; 256])),
+            nonce: ethereum_types::H64::random().into(),
+            transactions: tx_hashes,
+            mix_hash: ethereum_types::H256::random().into(),
+            hash: Default::default(),
+            parent_hash: ethereum_types::H256::random().into(),
+            uncles_hash: ethereum_types::H256::random().into(),
+            state_root: ethereum_types::H256::random().into(),
+            transactions_root: ethereum_types::H256::random().into(),
+            receipts_root: ethereum_types::H256::random().into(),
+            gas_used: U256::from(rand::random::<u64>()),
+            gas_limit: U256::from(rand::random::<u64>()),
+            extra_data: Default::default(),
+            timestamp: U256::from(rand::random::<u64>()),
+            difficulty: U256::from(rand::random::<u64>()),
+            total_difficulty: Default::default(),
+            seal_fields: Vec::new(),
+            uncles: Vec::new(),
+            size: None,
+            base_fee_per_gas: Some(U256::from(rand::random::<u64>())),
+        };
+
+        let full_block = block.clone().into_full_block(transactions.clone());
+        assert_eq!(full_block.transactions, transactions);
+
+        let block_from_full_block: Block<H256> = full_block.into();
+        assert_eq!(block_from_full_block, block);
+
+    }
+
 }

--- a/src/did/src/block.rs
+++ b/src/did/src/block.rs
@@ -496,10 +496,6 @@ impl ExeResult {
     }
 }
 
-// impl From<ethers_core::types::Exe> for Block<T> {
-
-// }
-
 impl Storable for ExeResult {
     const BOUND: Bound = Bound::Unbounded;
 

--- a/src/eth-signer/src/sign_strategy.rs
+++ b/src/eth-signer/src/sign_strategy.rs
@@ -19,6 +19,7 @@ pub enum TransactionSignerError {
     #[error("wallet error: {0}")]
     WalletError(#[from] crate::WalletError),
 
+    #[cfg(feature = "ic_sign")]
     #[error("ic sign error: {0}")]
     IcSignError(#[from] crate::ic_sign::IcSignerError),
 

--- a/src/evm-block-extractor/src/block_extractor.rs
+++ b/src/evm-block-extractor/src/block_extractor.rs
@@ -2,7 +2,6 @@ use std::sync::Arc;
 
 use ethereum_json_rpc_client::reqwest::ReqwestClient;
 use ethereum_json_rpc_client::EthJsonRcpClient;
-use ethers_core::types::{Block, BlockNumber, H256};
 use itertools::Itertools;
 use tokio::time::Duration;
 
@@ -52,7 +51,7 @@ impl BlockExtractor {
         for blocks_batch in &(from_block_inclusive..=to_block_inclusive).chunks(batch_size) {
             let block_numbers = blocks_batch
                 .into_iter()
-                .map(|block| BlockNumber::Number(block.into()));
+                .map(|block| ethers_core::types::BlockNumber::Number(block.into()));
 
             let evm_blocks = tokio::time::timeout(
                 Duration::from_secs(request_time_out_secs),
@@ -71,7 +70,7 @@ impl BlockExtractor {
             let blocks = evm_blocks
                 .into_iter()
                 .map(|block| block.into())
-                .collect::<Vec<Block<H256>>>();
+                .collect::<Vec<ethers_core::types::Block<ethers_core::types::H256>>>();
 
             for block in &blocks {
                 let tx_hashes = block.transactions.clone();
@@ -97,6 +96,16 @@ impl BlockExtractor {
                     }
                 }
             }
+
+            let blocks = blocks
+                .into_iter()
+                .map(|block| block.into())
+                .collect::<Vec<did::Block<did::H256>>>();
+
+            let all_transactions = all_transactions
+                .into_iter()
+                .map(|tx| tx.into())
+                .collect::<Vec<did::Transaction>>();
 
             self.blockchain
                 .insert_block_data(&blocks, &all_evm_receipts, &all_transactions)

--- a/src/evm-block-extractor/src/database/big_query_db_client.rs
+++ b/src/evm-block-extractor/src/database/big_query_db_client.rs
@@ -1,6 +1,7 @@
 use std::fmt::Debug;
 
-use ethers_core::types::{Block, Transaction, TransactionReceipt, H256};
+use did::{Block, Transaction, H256};
+use ethers_core::types::TransactionReceipt;
 use gcp_bigquery_client::model::dataset::Dataset;
 use gcp_bigquery_client::model::field_type::serialize_json_as_string;
 use gcp_bigquery_client::model::query_parameter::QueryParameter;
@@ -276,14 +277,7 @@ impl DatabaseClient for BigQueryDbClient {
             .map(|b| {
                 let block_id = b
                     .number
-                    .ok_or(anyhow::anyhow!("Block number not found"))
-                    .expect("Block number not found")
-                    .as_u64();
-
-                let block_hash = b
-                    .hash
-                    .ok_or(anyhow::anyhow!("Block hash not found"))
-                    .expect("Block hash not found");
+                    .0.as_u64();
 
                 let block_row = BlockRow {
                     id: block_id,
@@ -291,7 +285,7 @@ impl DatabaseClient for BigQueryDbClient {
                 };
 
                 TableDataInsertAllRequestRows {
-                    insert_id: Some(format!("0x{:x}", block_hash)),
+                    insert_id: Some(b.hash.to_hex_str()),
                     json: serde_json::to_value(block_row).expect("Failed to serialize block"),
                 }
             })
@@ -303,13 +297,13 @@ impl DatabaseClient for BigQueryDbClient {
         let transactions = transactions
             .iter()
             .map(|txn| {
-                let tx_hash = txn.hash;
+                let tx_hash = &txn.hash;
 
                 let txn = TransactionRow {
                     tx_hash: format!("0x{:x}", tx_hash),
                     transaction: serde_json::to_value(txn)
                         .expect("Failed to serialize transaction"),
-                    block_number: txn.block_number.expect("Block number not found").as_u64(),
+                    block_number: txn.block_number.expect("Block number not found").0.as_u64(),
                 };
 
                 TableDataInsertAllRequestRows {

--- a/src/evm-block-extractor/src/database/mod.rs
+++ b/src/evm-block-extractor/src/database/mod.rs
@@ -1,7 +1,8 @@
 pub mod big_query_db_client;
 pub mod postgres_db_client;
 
-use ethers_core::types::{Block, Transaction, TransactionReceipt, H256};
+use did::{Block, Transaction, H256};
+use ethers_core::types::TransactionReceipt;
 
 /// A trait for interacting with a blockchain database
 #[async_trait::async_trait]

--- a/src/evm-block-extractor/src/database/postgres_db_client.rs
+++ b/src/evm-block-extractor/src/database/postgres_db_client.rs
@@ -1,6 +1,7 @@
 use ::sqlx::migrate::Migrator;
 use ::sqlx::*;
-use ethers_core::types::{Block, Transaction, TransactionReceipt, H256};
+use did::{Block, Transaction, H256};
+use ethers_core::types::TransactionReceipt;
 use serde::de::DeserializeOwned;
 use sqlx::postgres::PgRow;
 
@@ -66,9 +67,7 @@ impl DatabaseClient for PostgresDbClient {
 
         for block in blocks {
             let block_id = block
-                .number
-                .ok_or(anyhow::anyhow!("Block number not found"))?
-                .as_u64();
+                .number.0.as_u64();
 
             sqlx::query("INSERT INTO EVM_BLOCK (id, data) VALUES ($1, $2)")
                 .bind(block_id as i64)
@@ -89,11 +88,11 @@ impl DatabaseClient for PostgresDbClient {
         }
 
         for txn in transactions {
-            let hex_tx_hash = did::H256::from(txn.hash).to_hex_str();
+            let hex_tx_hash = txn.hash.to_hex_str();
             sqlx::query("INSERT INTO EVM_TRANSACTION (id, data,block_number) VALUES ($1, $2,$3)")
                 .bind(&hex_tx_hash)
                 .bind(serde_json::to_value(txn)?)
-                .bind(txn.block_number.expect("Block number not found").as_u64() as i64)
+                .bind(txn.block_number.expect("Block number not found").0.as_u64() as i64)
                 .execute(&mut *tx)
                 .await?;
         }

--- a/src/evm-block-extractor/src/rpc.rs
+++ b/src/evm-block-extractor/src/rpc.rs
@@ -152,7 +152,7 @@ impl EthServer for EthImpl {
     async fn get_transaction_receipt(&self, tx_hash: H256) -> RpcResult<TransactionReceipt> {
         let tx = self
             .blockchain
-            .get_transaction_receipt(tx_hash)
+            .get_transaction_receipt(tx_hash.into())
             .await
             .map_err(|e| {
                 log::error!("Error getting transaction receipt: {:?}", e);

--- a/src/evm-block-extractor/tests/tests/block_extractor_it.rs
+++ b/src/evm-block-extractor/tests/tests/block_extractor_it.rs
@@ -43,9 +43,9 @@ async fn test_extractor_collect_blocks() {
 
             // Check blocks
             {
-                assert_eq!(block_num, full_block.number.unwrap().as_u64());
-                assert_eq!(block_num, block.number.unwrap().as_u64());
-                assert_eq!(block.hash.unwrap(), full_block.hash.unwrap());
+                assert_eq!(block_num, full_block.number.0.as_u64());
+                assert_eq!(block_num, block.number.0.as_u64());
+                assert_eq!(block.hash, full_block.hash);
             }
 
             // Check transactions
@@ -62,11 +62,11 @@ async fn test_extractor_collect_blocks() {
             // Check receipts
             {
                 for tx in &full_block.transactions {
-                    let receipt = db_client.get_transaction_receipt(tx.hash).await.unwrap();
+                    let receipt = db_client.get_transaction_receipt(tx.hash.clone()).await.unwrap();
 
-                    assert_eq!(tx.hash, receipt.transaction_hash);
-                    assert_eq!(tx.block_number, receipt.block_number);
-                    assert_eq!(tx.block_hash, receipt.block_hash);
+                    assert_eq!(tx.hash.0, receipt.transaction_hash);
+                    assert_eq!(tx.block_number.unwrap().0, receipt.block_number.unwrap());
+                    assert_eq!(tx.block_hash.clone().unwrap().0, receipt.block_hash.unwrap());
                 }
             }
         }

--- a/src/evm-block-extractor/tests/tests/database_client_it.rs
+++ b/src/evm-block-extractor/tests/tests/database_client_it.rs
@@ -158,7 +158,7 @@ async fn test_retrieval_of_transactions_with_blocks() {
 
         for i in 1..=10 {
             let dummy_block: Block<H256> = Block {
-                number: ethers_core::types::U64::from(1).into(),
+                number: ethers_core::types::U64::from(i).into(),
                 hash: ethers_core::types::H256::random().into(),
                 ..Default::default()
             };


### PR DESCRIPTION
# Issue ticket

Issue ticket link: <>

## Checklist before requesting a review

### Code conventions

- [ ] I have performed a self-review of my code
- [ ] Every new function is documented
- [ ] Object names are auto explicative

### Security

- [ ] The PR does not break APIs backward compatibility
- [ ] The PR does not break the stable storage backward compatibility

### Testing

- [ ] Every function is properly unit tested
- [ ] I have added integration tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] IC endpoints are always tested through the `canister_call!` macro
