### PR TITLE
[EPROD-690] Persist `StorableExecutionResult` in the database

### DIFF
--- a/src/did/src/block.rs
+++ b/src/did/src/block.rs
@@ -109,6 +109,35 @@ impl Block<H256> {
             base_fee_per_gas: None,
         }
     }
+
+        /// Converts this block that only holds transaction hashes into a full block with `Transaction`
+        pub fn into_full_block(self, transactions: Vec<Transaction>) -> Block<Transaction> {
+                Block {
+                    hash: self.hash,
+                    parent_hash: self.parent_hash,
+                    uncles_hash: self.uncles_hash,
+                    author: self.author,
+                    state_root: self.state_root,
+                    transactions_root: self.transactions_root,
+                    receipts_root: self.receipts_root,
+                    number: self.number,
+                    gas_used: self.gas_used,
+                    gas_limit: self.gas_limit,
+                    extra_data: self.extra_data,
+                    logs_bloom: self.logs_bloom,
+                    timestamp: self.timestamp,
+                    difficulty: self.difficulty,
+                    total_difficulty: self.total_difficulty,
+                    seal_fields: self.seal_fields,
+                    uncles: self.uncles,
+                    size: self.size,
+                    mix_hash: self.mix_hash,
+                    nonce: self.nonce,
+                    base_fee_per_gas: self.base_fee_per_gas,
+                    transactions,
+                }
+            }
+    
 }
 
 impl Default for Block<H256> {
@@ -803,4 +832,58 @@ mod test {
             42u64.into(),
         )));
     }
+
+    #[test]
+    fn test_block_into_full_block() {
+
+        let transactions = vec![
+            create_transaction(
+                Some(U256::from(rand::random::<u64>())),
+                1,
+            ),
+            create_transaction(
+                Some(U256::from(rand::random::<u64>())),
+                2,
+            ),
+            create_transaction(
+                Some(U256::from(rand::random::<u64>())),
+                3,
+            )
+        ];
+
+        let tx_hashes = transactions.iter().map(|tx| tx.hash.clone()).collect::<Vec<_>>();
+
+        let block = Block::<H256> {
+            author: ethereum_types::H160::random().into(),
+            number: U64::from(rand::random::<u64>()),
+            logs_bloom: Bloom(ethereum_types::Bloom::from_slice(&[4u8; 256])),
+            nonce: ethereum_types::H64::random().into(),
+            transactions: tx_hashes,
+            mix_hash: ethereum_types::H256::random().into(),
+            hash: Default::default(),
+            parent_hash: ethereum_types::H256::random().into(),
+            uncles_hash: ethereum_types::H256::random().into(),
+            state_root: ethereum_types::H256::random().into(),
+            transactions_root: ethereum_types::H256::random().into(),
+            receipts_root: ethereum_types::H256::random().into(),
+            gas_used: U256::from(rand::random::<u64>()),
+            gas_limit: U256::from(rand::random::<u64>()),
+            extra_data: Default::default(),
+            timestamp: U256::from(rand::random::<u64>()),
+            difficulty: U256::from(rand::random::<u64>()),
+            total_difficulty: Default::default(),
+            seal_fields: Vec::new(),
+            uncles: Vec::new(),
+            size: None,
+            base_fee_per_gas: Some(U256::from(rand::random::<u64>())),
+        };
+
+        let full_block = block.clone().into_full_block(transactions.clone());
+        assert_eq!(full_block.transactions, transactions);
+
+        let block_from_full_block: Block<H256> = full_block.into();
+        assert_eq!(block_from_full_block, block);
+
+    }
+
 }

--- a/src/did/src/block.rs
+++ b/src/did/src/block.rs
@@ -110,34 +110,33 @@ impl Block<H256> {
         }
     }
 
-        /// Converts this block that only holds transaction hashes into a full block with `Transaction`
-        pub fn into_full_block(self, transactions: Vec<Transaction>) -> Block<Transaction> {
-                Block {
-                    hash: self.hash,
-                    parent_hash: self.parent_hash,
-                    uncles_hash: self.uncles_hash,
-                    author: self.author,
-                    state_root: self.state_root,
-                    transactions_root: self.transactions_root,
-                    receipts_root: self.receipts_root,
-                    number: self.number,
-                    gas_used: self.gas_used,
-                    gas_limit: self.gas_limit,
-                    extra_data: self.extra_data,
-                    logs_bloom: self.logs_bloom,
-                    timestamp: self.timestamp,
-                    difficulty: self.difficulty,
-                    total_difficulty: self.total_difficulty,
-                    seal_fields: self.seal_fields,
-                    uncles: self.uncles,
-                    size: self.size,
-                    mix_hash: self.mix_hash,
-                    nonce: self.nonce,
-                    base_fee_per_gas: self.base_fee_per_gas,
-                    transactions,
-                }
-            }
-    
+    /// Converts this block that only holds transaction hashes into a full block with `Transaction`
+    pub fn into_full_block(self, transactions: Vec<Transaction>) -> Block<Transaction> {
+        Block {
+            hash: self.hash,
+            parent_hash: self.parent_hash,
+            uncles_hash: self.uncles_hash,
+            author: self.author,
+            state_root: self.state_root,
+            transactions_root: self.transactions_root,
+            receipts_root: self.receipts_root,
+            number: self.number,
+            gas_used: self.gas_used,
+            gas_limit: self.gas_limit,
+            extra_data: self.extra_data,
+            logs_bloom: self.logs_bloom,
+            timestamp: self.timestamp,
+            difficulty: self.difficulty,
+            total_difficulty: self.total_difficulty,
+            seal_fields: self.seal_fields,
+            uncles: self.uncles,
+            size: self.size,
+            mix_hash: self.mix_hash,
+            nonce: self.nonce,
+            base_fee_per_gas: self.base_fee_per_gas,
+            transactions,
+        }
+    }
 }
 
 impl Default for Block<H256> {
@@ -835,23 +834,16 @@ mod test {
 
     #[test]
     fn test_block_into_full_block() {
-
         let transactions = vec![
-            create_transaction(
-                Some(U256::from(rand::random::<u64>())),
-                1,
-            ),
-            create_transaction(
-                Some(U256::from(rand::random::<u64>())),
-                2,
-            ),
-            create_transaction(
-                Some(U256::from(rand::random::<u64>())),
-                3,
-            )
+            create_transaction(Some(U256::from(rand::random::<u64>())), 1),
+            create_transaction(Some(U256::from(rand::random::<u64>())), 2),
+            create_transaction(Some(U256::from(rand::random::<u64>())), 3),
         ];
 
-        let tx_hashes = transactions.iter().map(|tx| tx.hash.clone()).collect::<Vec<_>>();
+        let tx_hashes = transactions
+            .iter()
+            .map(|tx| tx.hash.clone())
+            .collect::<Vec<_>>();
 
         let block = Block::<H256> {
             author: ethereum_types::H160::random().into(),
@@ -883,7 +875,5 @@ mod test {
 
         let block_from_full_block: Block<H256> = full_block.into();
         assert_eq!(block_from_full_block, block);
-
     }
-
 }

--- a/src/eth-signer/src/sign_strategy.rs
+++ b/src/eth-signer/src/sign_strategy.rs
@@ -19,6 +19,7 @@ pub enum TransactionSignerError {
     #[error("wallet error: {0}")]
     WalletError(#[from] crate::WalletError),
 
+    #[cfg(feature = "ic_sign")]
     #[error("ic sign error: {0}")]
     IcSignError(#[from] crate::ic_sign::IcSignerError),
 

--- a/src/ethereum-json-rpc-client/Cargo.toml
+++ b/src/ethereum-json-rpc-client/Cargo.toml
@@ -19,6 +19,7 @@ reqwest = ["dep:reqwest"]
 [dependencies]
 anyhow = { workspace = true }
 candid = { workspace = true }
+did = { path = "../did" }
 hex = { workspace = true }
 ic-exports = { workspace = true }
 ic-canister-client = { workspace = true, optional = true }

--- a/src/ethereum-json-rpc-client/src/lib.rs
+++ b/src/ethereum-json-rpc-client/src/lib.rs
@@ -25,7 +25,7 @@ const ETH_BLOCK_NUMBER_METHOD: &str = "eth_blockNumber";
 const ETH_GET_TRANSACTION_RECEIPT_METHOD: &str = "eth_getTransactionReceipt";
 const ETH_SEND_RAW_TRANSACTION_METHOD: &str = "eth_sendRawTransaction";
 const ETH_GET_LOGS_METHOD: &str = "eth_getLogs";
-const ETH_GET_TX_EXECUTION_RESULT_BY_HASH_METHOD: &str = "getExeResultByHash";
+const ETH_GET_TX_EXECUTION_RESULT_BY_HASH_METHOD: &str = "ic_getExeResultByHash";
 
 /// A client for interacting with an Ethereum node over JSON-RPC.
 #[derive(Clone)]

--- a/src/ethereum-json-rpc-client/src/lib.rs
+++ b/src/ethereum-json-rpc-client/src/lib.rs
@@ -2,6 +2,7 @@ use std::future::Future;
 use std::pin::Pin;
 
 use anyhow::Context;
+use did::transaction::StorableExecutionResult;
 use ethers_core::types::{
     Block, BlockNumber, Log, Transaction, TransactionReceipt, H160, H256, U64,
 };
@@ -24,6 +25,7 @@ const ETH_BLOCK_NUMBER_METHOD: &str = "eth_blockNumber";
 const ETH_GET_TRANSACTION_RECEIPT_METHOD: &str = "eth_getTransactionReceipt";
 const ETH_SEND_RAW_TRANSACTION_METHOD: &str = "eth_sendRawTransaction";
 const ETH_GET_LOGS_METHOD: &str = "eth_getLogs";
+const ETH_GET_TX_EXECUTION_RESULT_BY_HASH_METHOD: &str = "getExeResultByHash";
 
 /// A client for interacting with an Ethereum node over JSON-RPC.
 #[derive(Clone)]
@@ -165,6 +167,49 @@ impl<C: Client> EthJsonRcpClient<C> {
             Id::Str("ETH_GET_LOGS_METHOD".to_string()),
         )
         .await
+    }
+
+    /// Returns the transaction execution result by hash
+    pub async fn get_tx_execution_result_by_hash(
+        &self,
+        hash: H256,
+    ) -> anyhow::Result<StorableExecutionResult> {
+        let transaction = self
+            .single_request::<Option<StorableExecutionResult>>(
+                ETH_GET_TX_EXECUTION_RESULT_BY_HASH_METHOD.to_string(),
+                make_params_array!(hash),
+                Id::Str(hash.to_string()),
+            )
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("Transaction not found"))?;
+
+        Ok(transaction)
+    }
+
+    /// Returns the transaction execution result by hash in batch
+    pub async fn get_tx_execution_results_by_hash(
+        &self,
+        hashes: impl IntoIterator<Item = H256>,
+        max_batch_size: usize,
+    ) -> anyhow::Result<Vec<StorableExecutionResult>> {
+        let params = hashes
+            .into_iter()
+            .enumerate()
+            .map(|(index, hash)| -> anyhow::Result<(Params, Id)> {
+                Ok((make_params_array!(hash), Id::Num(index as _)))
+            })
+            .collect::<anyhow::Result<Vec<_>>>()?;
+
+        Ok(self
+            .batch_request::<Option<StorableExecutionResult>>(
+                ETH_GET_TX_EXECUTION_RESULT_BY_HASH_METHOD.to_string(),
+                params,
+                max_batch_size,
+            )
+            .await?
+            .into_iter()
+            .flatten()
+            .collect())
     }
 
     /// Performs a request.

--- a/src/evm-block-extractor/src/block_extractor.rs
+++ b/src/evm-block-extractor/src/block_extractor.rs
@@ -77,7 +77,9 @@ impl BlockExtractor {
                 let tx_hashes = block.transactions.clone();
                 let client = client.clone();
                 let receipts_task = tokio::spawn(async move {
-                    client.get_receipts_by_hash(tx_hashes, batch_size).await
+                    client
+                        .get_tx_execution_results_by_hash(tx_hashes, batch_size)
+                        .await
                 });
 
                 receipts_tasks.push(receipts_task);

--- a/src/evm-block-extractor/src/block_extractor.rs
+++ b/src/evm-block-extractor/src/block_extractor.rs
@@ -2,7 +2,6 @@ use std::sync::Arc;
 
 use ethereum_json_rpc_client::reqwest::ReqwestClient;
 use ethereum_json_rpc_client::EthJsonRcpClient;
-use ethers_core::types::{Block, BlockNumber, H256};
 use itertools::Itertools;
 use tokio::time::Duration;
 
@@ -52,7 +51,7 @@ impl BlockExtractor {
         for blocks_batch in &(from_block_inclusive..=to_block_inclusive).chunks(batch_size) {
             let block_numbers = blocks_batch
                 .into_iter()
-                .map(|block| BlockNumber::Number(block.into()));
+                .map(|block| ethers_core::types::BlockNumber::Number(block.into()));
 
             let evm_blocks = tokio::time::timeout(
                 Duration::from_secs(request_time_out_secs),
@@ -71,7 +70,7 @@ impl BlockExtractor {
             let blocks = evm_blocks
                 .into_iter()
                 .map(|block| block.into())
-                .collect::<Vec<Block<H256>>>();
+                .collect::<Vec<ethers_core::types::Block<ethers_core::types::H256>>>();
 
             for block in &blocks {
                 let tx_hashes = block.transactions.clone();
@@ -99,6 +98,16 @@ impl BlockExtractor {
                     }
                 }
             }
+
+            let blocks = blocks
+                .into_iter()
+                .map(|block| block.into())
+                .collect::<Vec<did::Block<did::H256>>>();
+
+            let all_transactions = all_transactions
+                .into_iter()
+                .map(|tx| tx.into())
+                .collect::<Vec<did::Transaction>>();
 
             self.blockchain
                 .insert_block_data(&blocks, &all_evm_receipts, &all_transactions)

--- a/src/evm-block-extractor/src/database/big_query_db_client.rs
+++ b/src/evm-block-extractor/src/database/big_query_db_client.rs
@@ -1,6 +1,7 @@
 use std::fmt::Debug;
 
-use did::{Block, Transaction, H256, TransactionReceipt, transaction::StorableExecutionResult};
+use did::transaction::StorableExecutionResult;
+use did::{Block, Transaction, TransactionReceipt, H256};
 use gcp_bigquery_client::model::dataset::Dataset;
 use gcp_bigquery_client::model::field_type::serialize_json_as_string;
 use gcp_bigquery_client::model::query_parameter::QueryParameter;
@@ -274,9 +275,7 @@ impl DatabaseClient for BigQueryDbClient {
         let blocks = block
             .iter()
             .map(|b| {
-                let block_id = b
-                    .number
-                    .0.as_u64();
+                let block_id = b.number.0.as_u64();
 
                 let block_row = BlockRow {
                     id: block_id,

--- a/src/evm-block-extractor/src/database/mod.rs
+++ b/src/evm-block-extractor/src/database/mod.rs
@@ -1,7 +1,8 @@
 pub mod big_query_db_client;
 pub mod postgres_db_client;
 
-use ethers_core::types::{Block, Transaction, TransactionReceipt, H256};
+use did::transaction::{StorableExecutionResult, TransactionReceipt};
+use ethers_core::types::{Block, Transaction, H256};
 
 /// A trait for interacting with a blockchain database
 #[async_trait::async_trait]
@@ -22,7 +23,7 @@ pub trait DatabaseClient: Send + Sync {
     async fn insert_block_data(
         &self,
         blocks: &[Block<H256>],
-        receipts: &[TransactionReceipt],
+        receipts: &[StorableExecutionResult],
         transactions: &[Transaction],
     ) -> anyhow::Result<()>;
 

--- a/src/evm-block-extractor/src/database/mod.rs
+++ b/src/evm-block-extractor/src/database/mod.rs
@@ -1,8 +1,7 @@
 pub mod big_query_db_client;
 pub mod postgres_db_client;
 
-use did::transaction::{StorableExecutionResult, TransactionReceipt};
-use ethers_core::types::{Block, Transaction, H256};
+use did::{Block, Transaction, H256, TransactionReceipt, transaction::StorableExecutionResult};
 
 /// A trait for interacting with a blockchain database
 #[async_trait::async_trait]

--- a/src/evm-block-extractor/src/database/mod.rs
+++ b/src/evm-block-extractor/src/database/mod.rs
@@ -1,7 +1,8 @@
 pub mod big_query_db_client;
 pub mod postgres_db_client;
 
-use did::{Block, Transaction, H256, TransactionReceipt, transaction::StorableExecutionResult};
+use did::transaction::StorableExecutionResult;
+use did::{Block, Transaction, TransactionReceipt, H256};
 
 /// A trait for interacting with a blockchain database
 #[async_trait::async_trait]

--- a/src/evm-block-extractor/src/database/postgres_db_client.rs
+++ b/src/evm-block-extractor/src/database/postgres_db_client.rs
@@ -1,7 +1,6 @@
 use ::sqlx::migrate::Migrator;
 use ::sqlx::*;
-use did::transaction::{StorableExecutionResult, TransactionReceipt};
-use ethers_core::types::{Block, Transaction, H256};
+use did::{Block, Transaction, H256, TransactionReceipt, transaction::StorableExecutionResult};
 use serde::de::DeserializeOwned;
 use sqlx::postgres::PgRow;
 
@@ -67,9 +66,7 @@ impl DatabaseClient for PostgresDbClient {
 
         for block in blocks {
             let block_id = block
-                .number
-                .ok_or(anyhow::anyhow!("Block number not found"))?
-                .as_u64();
+                .number.0.as_u64();
 
             sqlx::query("INSERT INTO EVM_BLOCK (id, data) VALUES ($1, $2)")
                 .bind(block_id as i64)
@@ -90,11 +87,11 @@ impl DatabaseClient for PostgresDbClient {
         }
 
         for txn in transactions {
-            let hex_tx_hash = did::H256::from(txn.hash).to_hex_str();
+            let hex_tx_hash = txn.hash.to_hex_str();
             sqlx::query("INSERT INTO EVM_TRANSACTION (id, data,block_number) VALUES ($1, $2,$3)")
                 .bind(&hex_tx_hash)
                 .bind(serde_json::to_value(txn)?)
-                .bind(txn.block_number.expect("Block number not found").as_u64() as i64)
+                .bind(txn.block_number.expect("Block number not found").0.as_u64() as i64)
                 .execute(&mut *tx)
                 .await?;
         }

--- a/src/evm-block-extractor/src/database/postgres_db_client.rs
+++ b/src/evm-block-extractor/src/database/postgres_db_client.rs
@@ -1,6 +1,7 @@
 use ::sqlx::migrate::Migrator;
 use ::sqlx::*;
-use did::{Block, Transaction, H256, TransactionReceipt, transaction::StorableExecutionResult};
+use did::transaction::StorableExecutionResult;
+use did::{Block, Transaction, TransactionReceipt, H256};
 use serde::de::DeserializeOwned;
 use sqlx::postgres::PgRow;
 
@@ -65,8 +66,7 @@ impl DatabaseClient for PostgresDbClient {
         let mut tx = self.pool.begin().await?;
 
         for block in blocks {
-            let block_id = block
-                .number.0.as_u64();
+            let block_id = block.number.0.as_u64();
 
             sqlx::query("INSERT INTO EVM_BLOCK (id, data) VALUES ($1, $2)")
                 .bind(block_id as i64)

--- a/src/evm-block-extractor/src/rpc.rs
+++ b/src/evm-block-extractor/src/rpc.rs
@@ -1,9 +1,9 @@
-use std::sync::Arc;
-
-use ethers_core::types::{BlockNumber, TransactionReceipt, H256, U256, U64};
+use did::TransactionReceipt;
+use ethers_core::types::{BlockNumber, H256, U256, U64};
 use ethers_core::utils::rlp::{RlpStream, EMPTY_LIST_RLP};
 use jsonrpsee::core::RpcResult;
 use jsonrpsee::proc_macros::rpc;
+use std::sync::Arc;
 
 use crate::database::DatabaseClient;
 

--- a/src/evm-block-extractor/src/rpc.rs
+++ b/src/evm-block-extractor/src/rpc.rs
@@ -1,9 +1,10 @@
+use std::sync::Arc;
+
 use did::TransactionReceipt;
 use ethers_core::types::{BlockNumber, H256, U256, U64};
 use ethers_core::utils::rlp::{RlpStream, EMPTY_LIST_RLP};
 use jsonrpsee::core::RpcResult;
 use jsonrpsee::proc_macros::rpc;
-use std::sync::Arc;
 
 use crate::database::DatabaseClient;
 

--- a/src/evm-block-extractor/src/rpc.rs
+++ b/src/evm-block-extractor/src/rpc.rs
@@ -152,7 +152,7 @@ impl EthServer for EthImpl {
     async fn get_transaction_receipt(&self, tx_hash: H256) -> RpcResult<TransactionReceipt> {
         let tx = self
             .blockchain
-            .get_transaction_receipt(tx_hash)
+            .get_transaction_receipt(tx_hash.into())
             .await
             .map_err(|e| {
                 log::error!("Error getting transaction receipt: {:?}", e);

--- a/src/evm-block-extractor/src_resources/db/postgres/migrations/00001_create_schema.sql
+++ b/src/evm-block-extractor/src_resources/db/postgres/migrations/00001_create_schema.sql
@@ -12,15 +12,15 @@ create table EVM_BLOCK (
 
 
 -----------------------------------------
--- Begin - EVM_TRANSACTION_RECEIPT -
+-- Begin - EVM_TRANSACTION_EXE_RESULT -
 -----------------------------------------
 
-create table EVM_TRANSACTION_RECEIPT (
+create table EVM_TRANSACTION_EXE_RESULT (
     ID char(66) primary key, -- 64 is the length of a H256 in hex, plus 0x
     DATA JSONB
 );
 
--- End - EVM_TRANSACTION_RECEIPT -
+-- End - EVM_TRANSACTION_EXE_RESULT -
 
 
 -----------------------------------------

--- a/src/evm-block-extractor/tests/tests/block_extractor_it.rs
+++ b/src/evm-block-extractor/tests/tests/block_extractor_it.rs
@@ -43,9 +43,9 @@ async fn test_extractor_collect_blocks() {
 
             // Check blocks
             {
-                assert_eq!(block_num, full_block.number.unwrap().as_u64());
-                assert_eq!(block_num, block.number.unwrap().as_u64());
-                assert_eq!(block.hash.unwrap(), full_block.hash.unwrap());
+                assert_eq!(block_num, full_block.number.0.as_u64());
+                assert_eq!(block_num, block.number.0.as_u64());
+                assert_eq!(block.hash, full_block.hash);
             }
 
             // Check transactions
@@ -62,11 +62,11 @@ async fn test_extractor_collect_blocks() {
             // Check receipts
             {
                 for tx in &full_block.transactions {
-                    let receipt = db_client.get_transaction_receipt(tx.hash).await.unwrap();
+                    let receipt = db_client.get_transaction_receipt(tx.hash.clone()).await.unwrap();
 
-                    assert_eq!(tx.hash, receipt.transaction_hash.into());
-                    assert_eq!(tx.block_number, Some(receipt.block_number.into()));
-                    assert_eq!(tx.block_hash, Some(receipt.block_hash.into()));
+                    assert_eq!(tx.hash, receipt.transaction_hash);
+                    assert_eq!(tx.block_number, Some(receipt.block_number));
+                    assert_eq!(tx.block_hash, Some(receipt.block_hash));
                 }
             }
         }

--- a/src/evm-block-extractor/tests/tests/block_extractor_it.rs
+++ b/src/evm-block-extractor/tests/tests/block_extractor_it.rs
@@ -64,9 +64,9 @@ async fn test_extractor_collect_blocks() {
                 for tx in &full_block.transactions {
                     let receipt = db_client.get_transaction_receipt(tx.hash).await.unwrap();
 
-                    assert_eq!(tx.hash, receipt.transaction_hash);
-                    assert_eq!(tx.block_number, receipt.block_number);
-                    assert_eq!(tx.block_hash, receipt.block_hash);
+                    assert_eq!(tx.hash, receipt.transaction_hash.into());
+                    assert_eq!(tx.block_number, Some(receipt.block_number.into()));
+                    assert_eq!(tx.block_hash, Some(receipt.block_hash.into()));
                 }
             }
         }

--- a/src/evm-block-extractor/tests/tests/block_extractor_it.rs
+++ b/src/evm-block-extractor/tests/tests/block_extractor_it.rs
@@ -62,7 +62,10 @@ async fn test_extractor_collect_blocks() {
             // Check receipts
             {
                 for tx in &full_block.transactions {
-                    let receipt = db_client.get_transaction_receipt(tx.hash.clone()).await.unwrap();
+                    let receipt = db_client
+                        .get_transaction_receipt(tx.hash.clone())
+                        .await
+                        .unwrap();
 
                     assert_eq!(tx.hash, receipt.transaction_hash);
                     assert_eq!(tx.block_number, Some(receipt.block_number));

--- a/src/evm-block-extractor/tests/tests/database_client_it.rs
+++ b/src/evm-block-extractor/tests/tests/database_client_it.rs
@@ -52,7 +52,7 @@ async fn test_batch_insertion_of_blocks_and_receipts_transactions_retrieval() {
             let tx_hash = &exe_results[i].transaction_hash;
             let block_number = blocks[i].number.0.as_u64();
             let dummy_txn = Transaction {
-                hash: tx_hash.clone().into(),
+                hash: tx_hash.clone(),
                 block_number: Some(U64::from(block_number)),
                 ..Default::default()
             };

--- a/src/evm-canister-client/src/client.rs
+++ b/src/evm-canister-client/src/client.rs
@@ -3,6 +3,7 @@ use did::block::{BlockResult, ExeResult};
 use did::error::Result;
 use did::permission::{Permission, PermissionList};
 use did::state::{BasicAccount, FullStorageValue, Indices, StateUpdateAction};
+use did::transaction::StorableExecutionResult;
 use did::{
     Block, BlockNumber, Bytes, EstimateGasRequest, Transaction, TransactionReceipt, H160, H256,
     U256, U64,
@@ -763,6 +764,16 @@ impl<C: CanisterClient> EvmCanisterClient<C> {
     ) -> CanisterClientResult<Result<()>> {
         self.client
             .update("admin_set_max_batch_requests", (size,))
+            .await
+    }
+
+    /// Returns the execution result of a transaction by transaction hash.
+    pub async fn get_tx_execution_result_by_hash(
+        &self,
+        hash: H256,
+    ) -> CanisterClientResult<Option<StorableExecutionResult>> {
+        self.client
+            .query("get_tx_execution_result_by_hash", (hash,))
             .await
     }
 }


### PR DESCRIPTION
# Issue ticket

Issue ticket link: <>

## Checklist before requesting a review

### Code conventions

- [x] I have performed a self-review of my code
- [x] Every new function is documented
- [x] Object names are auto explicative

### Security

- [x] The PR does not break APIs backward compatibility
- [x] The PR does not break the stable storage backward compatibility

### Testing

- [x] Every function is properly unit tested
- [x] I have added integration tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] IC endpoints are always tested through the `canister_call!` macro
