### PR TITLE
[EPROD-726] Calculate next block base fee arithmetic overflow

### DIFF
--- a/src/did/src/block.rs
+++ b/src/did/src/block.rs
@@ -831,6 +831,21 @@ mod test {
         );
     }
 
+    #[test]
+    fn should_calc_base_fee_with_arithmetic_overflow() {
+        let gas_used = U256::new(200_u64.into());
+        let gas_limit = U256::new(100_u64.into());
+        let mut base_fee = U256::new(100_u64.into());
+
+        for _ in 0..1000 {
+            base_fee = calculate_next_block_base_fee(
+                &gas_used,
+                &gas_limit,
+                &base_fee
+            );
+        };
+    }
+
     fn check_serialization_roundtrip<T>(val: &T)
     where
         for<'a> T: CandidType + Serialize + Deserialize<'a> + Eq + Debug,

--- a/src/did/src/block.rs
+++ b/src/did/src/block.rs
@@ -833,11 +833,11 @@ mod test {
 
     #[test]
     fn should_calc_base_fee_with_arithmetic_overflow() {
-        let gas_used = U256::new(200_u64.into());
+        let gas_used = U256::new(2000_u64.into());
         let gas_limit = U256::new(100_u64.into());
         let mut base_fee = U256::new(100_u64.into());
 
-        for _ in 0..1000 {
+        for _ in 0..100 {
             base_fee = calculate_next_block_base_fee(
                 &gas_used,
                 &gas_limit,


### PR DESCRIPTION
# Issue ticket

Issue ticket link: <>
[calculate_next_block_base_fee_arithmetic_overflow](https://infinityswap.atlassian.net/browse/EPROD-726)

## Checklist before requesting a review

### Code conventions

- [ ] I have performed a self-review of my code
- [ ] Every new function is documented
- [ ] Object names are auto explicative

### Security

- [ ] The PR does not break APIs backward compatibility
- [ ] The PR does not break the stable storage backward compatibility

### Testing

- [ ] Every function is properly unit tested
- [ ] I have added integration tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] IC endpoints are always tested through the `canister_call!` macro
