### PR TITLE
[EPROD-727] Fix null ID for eth_blockNumber

### DIFF
--- a/src/ethereum-json-rpc-client/src/lib.rs
+++ b/src/ethereum-json-rpc-client/src/lib.rs
@@ -131,7 +131,7 @@ impl<C: Client> EthJsonRcpClient<C> {
         self.single_request::<U64>(
             ETH_BLOCK_NUMBER_METHOD.to_string(),
             make_params_array!(),
-            Id::Null,
+            Id::Str("eth_blockNumber".to_string()),
         )
         .await
         .map(|v| v.as_u64())


### PR DESCRIPTION
# Issue ticket

Issue ticket link: <>

## Checklist before requesting a review

### Code conventions

- [x] I have performed a self-review of my code
- [x] Every new function is documented
- [x] Object names are auto explicative

### Security

- [x] The PR does not break APIs backward compatibility
- [x] The PR does not break the stable storage backward compatibility

### Testing

- [x] Every function is properly unit tested
- [x] I have added integration tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] IC endpoints are always tested through the `canister_call!` macro
