### PR TITLE
Fix typo in RPC struct name

### DIFF
--- a/src/ethereum-json-rpc-client/src/lib.rs
+++ b/src/ethereum-json-rpc-client/src/lib.rs
@@ -29,19 +29,19 @@ const ETH_GET_LOGS_METHOD: &str = "eth_getLogs";
 const IC_GET_TX_EXECUTION_RESULT_BY_HASH_METHOD: &str = "ic_getExeResultByHash";
 const IC_GET_GENESIS_BALANCES: &str = "ic_getGenesisBalances";
 
-/// A client for interacting with an Ethereum node over JSON-RPC.
-#[derive(Clone)]
-pub struct EthJsonRcpClient<C: Client> {
-    client: C,
-}
-
 macro_rules! make_params_array {
     ($($items:expr),*) => {
         Params::Array(vec![$(serde_json::to_value($items)?, )*])
     };
 }
 
-impl<C: Client> EthJsonRcpClient<C> {
+/// A client for interacting with an Ethereum node over JSON-RPC.
+#[derive(Clone)]
+pub struct EthJsonRpcClient<C: Client> {
+    client: C,
+}
+
+impl<C: Client> EthJsonRpcClient<C> {
     /// Create a new client.
     ///
     /// # Arguments

--- a/src/ethereum-json-rpc-client/tests/reqwest/mod.rs
+++ b/src/ethereum-json-rpc-client/tests/reqwest/mod.rs
@@ -1,5 +1,5 @@
 use ethereum_json_rpc_client::reqwest::ReqwestClient;
-use ethereum_json_rpc_client::{EthGetLogsParams, EthJsonRcpClient};
+use ethereum_json_rpc_client::{EthGetLogsParams, EthJsonRpcClient};
 use ethers_core::types::{BlockNumber, Log, H256};
 
 const ETHEREUM_JSON_API_URL: &str = "https://cloudflare-eth.com/";
@@ -13,8 +13,8 @@ fn to_hash(string: &str) -> H256 {
     )
 }
 
-fn reqwest_client() -> EthJsonRcpClient<ReqwestClient> {
-    EthJsonRcpClient::new(ReqwestClient::new(ETHEREUM_JSON_API_URL.to_string()))
+fn reqwest_client() -> EthJsonRpcClient<ReqwestClient> {
+    EthJsonRpcClient::new(ReqwestClient::new(ETHEREUM_JSON_API_URL.to_string()))
 }
 
 #[tokio::test]

--- a/src/evm-block-extractor/src/main.rs
+++ b/src/evm-block-extractor/src/main.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use clap::Parser;
 use env_logger::Builder;
 use ethereum_json_rpc_client::reqwest::ReqwestClient;
-use ethereum_json_rpc_client::EthJsonRcpClient;
+use ethereum_json_rpc_client::EthJsonRpcClient;
 use evm_block_extractor::config::ExtractorArgs;
 use evm_block_extractor::server::{server_start, server_stop};
 use evm_block_extractor::task::block_extractor::start_extractor;
@@ -33,7 +33,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     );
     info!("----------------------");
 
-    let evm_client = Arc::new(EthJsonRcpClient::new(ReqwestClient::new(
+    let evm_client = Arc::new(EthJsonRpcClient::new(ReqwestClient::new(
         config.remote_rpc_url.clone(),
     )));
     let db_client = config.command.clone().build_client().await?;

--- a/src/evm-block-extractor/src/task/block_extractor.rs
+++ b/src/evm-block-extractor/src/task/block_extractor.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use ethereum_json_rpc_client::reqwest::ReqwestClient;
-use ethereum_json_rpc_client::EthJsonRcpClient;
+use ethereum_json_rpc_client::EthJsonRpcClient;
 use ethers_core::types::BlockNumber;
 use log::*;
 use tokio::time::Duration;
@@ -13,7 +13,7 @@ use crate::database::{AccountBalance, DatabaseClient};
 pub async fn start_extractor(
     config: ExtractorArgs,
     db_client: Arc<dyn DatabaseClient>,
-    evm_client: Arc<EthJsonRcpClient<ReqwestClient>>,
+    evm_client: Arc<EthJsonRpcClient<ReqwestClient>>,
 ) -> anyhow::Result<()> {
     let earliest_block = evm_client
         .get_block_by_number(BlockNumber::Earliest)
@@ -45,7 +45,7 @@ pub async fn start_extractor(
 
 /// Extracts blocks from an EVMC and stores them in a database
 pub struct BlockExtractor {
-    client: Arc<EthJsonRcpClient<ReqwestClient>>,
+    client: Arc<EthJsonRpcClient<ReqwestClient>>,
     request_time_out_secs: u64,
     rpc_batch_size: usize,
     blockchain: Arc<dyn DatabaseClient>,
@@ -53,7 +53,7 @@ pub struct BlockExtractor {
 
 impl BlockExtractor {
     pub fn new(
-        client: Arc<EthJsonRcpClient<ReqwestClient>>,
+        client: Arc<EthJsonRpcClient<ReqwestClient>>,
         request_time_out_secs: u64,
         rpc_batch_size: usize,
         blockchain: Arc<dyn DatabaseClient>,

--- a/src/evm-block-extractor/tests/tests/block_extractor_it.rs
+++ b/src/evm-block-extractor/tests/tests/block_extractor_it.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use ethereum_json_rpc_client::reqwest::ReqwestClient;
-use ethereum_json_rpc_client::EthJsonRcpClient;
+use ethereum_json_rpc_client::EthJsonRpcClient;
 use evm_block_extractor::database::AccountBalance;
 use evm_block_extractor::task::block_extractor::BlockExtractor;
 
@@ -13,7 +13,7 @@ async fn test_extractor_collect_blocks() {
         db_client.init(None, false).await.unwrap();
 
         let rpc_url = "https://testnet.bitfinity.network".to_string();
-        let evm_client = Arc::new(EthJsonRcpClient::new(ReqwestClient::new(rpc_url)));
+        let evm_client = Arc::new(EthJsonRpcClient::new(ReqwestClient::new(rpc_url)));
 
         let request_time_out_secs = 10;
         let rpc_batch_size = 10;

--- a/src/evm-block-extractor/tests/tests/server_it.rs
+++ b/src/evm-block-extractor/tests/tests/server_it.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use did::{Block, H160, U256, U64};
 use ethereum_json_rpc_client::reqwest::ReqwestClient;
-use ethereum_json_rpc_client::{Client, EthJsonRcpClient};
+use ethereum_json_rpc_client::{Client, EthJsonRpcClient};
 use ethers_core::types::{BlockNumber, Transaction, H256};
 use evm_block_extractor::database::{AccountBalance, DatabaseClient};
 use evm_block_extractor::rpc::{EthImpl, EthServer, ICServer};
@@ -56,7 +56,7 @@ async fn test_get_blocks() {
         let (port, handle) = new_server(db_client).await;
 
         let http_client =
-            EthJsonRcpClient::new(ReqwestClient::new(format!("http://127.0.0.1:{port}")));
+            EthJsonRpcClient::new(ReqwestClient::new(format!("http://127.0.0.1:{port}")));
 
         let block_count = http_client.get_block_number().await.unwrap();
         assert_eq!(block_count, BLOCK_COUNT - 1);
@@ -199,7 +199,7 @@ async fn test_get_genesis_accounts() {
         let (port, handle) = new_server(db_client.clone()).await;
 
         let http_client =
-            EthJsonRcpClient::new(ReqwestClient::new(format!("http://127.0.0.1:{port}")));
+            EthJsonRpcClient::new(ReqwestClient::new(format!("http://127.0.0.1:{port}")));
 
         // Test on empty database
         {
@@ -260,7 +260,7 @@ async fn test_get_chain_id() {
         let (port, handle) = new_server(db_client.clone()).await;
 
         let http_client =
-            EthJsonRcpClient::new(ReqwestClient::new(format!("http://127.0.0.1:{port}")));
+            EthJsonRpcClient::new(ReqwestClient::new(format!("http://127.0.0.1:{port}")));
 
         let chain_id: u64 = random();
         db_client.insert_chain_id(chain_id).await.unwrap();


### PR DESCRIPTION
# Issue ticket

Issue ticket link: <>

## Checklist before requesting a review

### Code conventions

- [ ] I have performed a self-review of my code
- [ ] Every new function is documented
- [ ] Object names are auto explicative

### Security

- [ ] The PR does not break APIs backward compatibility
- [ ] The PR does not break the stable storage backward compatibility

### Testing

- [ ] Every function is properly unit tested
- [ ] I have added integration tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] IC endpoints are always tested through the `canister_call!` macro
