### PR TITLE
Disable inspect message evm endpoints

### DIFF
--- a/src/evm-canister-client/src/client.rs
+++ b/src/evm-canister-client/src/client.rs
@@ -843,4 +843,19 @@ impl<C: CanisterClient> EvmCanisterClient<C> {
             .query("is_zero_gas_price_transactions_enabled", ())
             .await
     }
+
+    /// Disable/Enable the inspect message
+    pub async fn admin_disable_inspect_message(
+        &mut self,
+        value: bool,
+    ) -> CanisterClientResult<Result<()>> {
+        self.client
+            .update("admin_disable_inspect_message", (value,))
+            .await
+    }
+
+    /// Returns whether the inspect message is disabled.
+    pub async fn is_inspect_message_disabled(&self) -> CanisterClientResult<bool> {
+        self.client.query("is_inspect_message_disabled", ()).await
+    }
 }

--- a/src/evm-canister-client/src/client.rs
+++ b/src/evm-canister-client/src/client.rs
@@ -814,7 +814,7 @@ impl<C: CanisterClient> EvmCanisterClient<C> {
 
     /// Enable/Disable transfers of tokens
     pub async fn admin_disable_token_transfer(
-        &mut self,
+        &self,
         value: bool,
     ) -> CanisterClientResult<Result<()>> {
         self.client
@@ -829,7 +829,7 @@ impl<C: CanisterClient> EvmCanisterClient<C> {
 
     /// Disable/Enable zero gas price transaction
     pub async fn admin_enable_zero_gas_price_transactions(
-        &mut self,
+        &self,
         enabled: bool,
     ) -> CanisterClientResult<Result<()>> {
         self.client
@@ -846,7 +846,7 @@ impl<C: CanisterClient> EvmCanisterClient<C> {
 
     /// Disable/Enable the inspect message
     pub async fn admin_disable_inspect_message(
-        &mut self,
+        &self,
         value: bool,
     ) -> CanisterClientResult<Result<()>> {
         self.client


### PR DESCRIPTION
# Issue ticket

Issue ticket link: <>

## Checklist before requesting a review

### Code conventions

- [ ] I have performed a self-review of my code
- [ ] Every new function is documented
- [ ] Object names are auto explicative

### Security

- [ ] The PR does not break APIs backward compatibility
- [ ] The PR does not break the stable storage backward compatibility

### Testing

- [ ] Every function is properly unit tested
- [ ] I have added integration tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] IC endpoints are always tested through the `canister_call!` macro
