### PR TITLE
Add runes id support for id256

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ solidity/broadcast/
 *.wasm.gz
 
 .cargo
+
+# IDE files
+.idea

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ edition = "2021"
 homepage = "https://github.com/bitfinity-network/bitfinity-evm-sdk"
 include = ["src/**/*", "LICENSE", "README.md"]
 license = "MIT"
-name = "bitfinity-evm-sdk"
 repository = "https://github.com/bitfinity-network/bitfinity-evm-sdk"
 version = "0.17.0"
 
@@ -55,6 +54,7 @@ log = "0.4"
 murmur3 = "0.5"
 num = "0.4"
 once_cell = "1.16"
+ordinals = "0.0.7"
 port_check = "0.2"
 rand = { version = "0.8", features = ["std_rng", "small_rng"] }
 reqwest = { version = "0.12", default-features = false }

--- a/src/minter-did/Cargo.toml
+++ b/src/minter-did/Cargo.toml
@@ -13,17 +13,22 @@ repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+default = []
+runes = ["ordinals"]
+
 [dependencies]
 candid = { workspace = true }
 did = { path = "../did" }
 eth-signer = { path = "../eth-signer" }
 ethers-core = { workspace = true }
+ic-canister-client = { workspace = true }
 ic-exports = { workspace = true, features = ["icrc"] }
 ic-log = { workspace = true }
 ic-stable-structures = { workspace = true }
+ordinals = { workspace = true, optional = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
-ic-canister-client = { workspace = true }
 
 [dev-dependencies]
 rand = { workspace = true }

--- a/src/minter-did/src/id256.rs
+++ b/src/minter-did/src/id256.rs
@@ -105,6 +105,11 @@ impl Id256 {
         H160::from_slice(&bytes)
     }
 
+    /// Convert BTC rune id into id256 type.
+    ///
+    /// Runes are identified by block_id/transaction index in which the rune was etched.
+    ///
+    /// If `runes` feature is enabled, `rune_id.into()` can be used with the same effect.
     pub fn from_rune_id(block_id: u64, tx_id: u32) -> Self {
         let mut buf = [0u8; Self::BYTE_SIZE];
 
@@ -118,6 +123,10 @@ impl Id256 {
         Self(buf)
     }
 
+    /// Converts Id256 into `(block_id, tx_id)` rune identifier if the ID represents the rune id,
+    /// or returns an error otherwise.
+    ///
+    /// If `runes` feature is enabled, `id.try_into()` can be used with the same effect.
     pub fn to_rune_id(&self) -> Result<(u64, u32), Error> {
         if self.0[0] != Self::RUNE_ID_MARK {
             return Err(Error::Internal("wrong rune id mark in Id256".into()));

--- a/src/minter-did/src/lib.rs
+++ b/src/minter-did/src/lib.rs
@@ -3,3 +3,7 @@ pub mod id256;
 pub mod init;
 pub mod order;
 pub mod reason;
+
+#[cfg(feature = "runes")]
+pub mod runes;
+

--- a/src/minter-did/src/runes.rs
+++ b/src/minter-did/src/runes.rs
@@ -2,15 +2,12 @@ use ordinals::{RuneId};
 use crate::error::Error;
 use crate::id256::Id256;
 
-
-#[cfg(feature = "runes")]
 impl From<RuneId> for Id256 {
     fn from(value: RuneId) -> Self {
         Self::from_btc_tx_index(value.block, value.tx)
     }
 }
 
-#[cfg(feature = "runes")]
 impl TryFrom<Id256> for RuneId {
     type Error = Error;
 
@@ -24,7 +21,6 @@ impl TryFrom<Id256> for RuneId {
 mod tests {
     use super::*;
 
-    #[cfg(feature = "runes")]
     #[test]
     fn to_from_rune_id() {
         let rune_id = RuneId { block: 256, tx: 42 };

--- a/src/minter-did/src/runes.rs
+++ b/src/minter-did/src/runes.rs
@@ -1,0 +1,35 @@
+use ordinals::{RuneId};
+use crate::error::Error;
+use crate::id256::Id256;
+
+
+#[cfg(feature = "runes")]
+impl From<RuneId> for Id256 {
+    fn from(value: RuneId) -> Self {
+        Self::from_btc_tx_index(value.block, value.tx)
+    }
+}
+
+#[cfg(feature = "runes")]
+impl TryFrom<Id256> for RuneId {
+    type Error = Error;
+
+    fn try_from(value: Id256) -> Result<Self, Self::Error> {
+        let (block, tx) = value.to_btc_tx_index()?;
+        Ok(RuneId { block, tx })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(feature = "runes")]
+    #[test]
+    fn to_from_rune_id() {
+        let rune_id = RuneId { block: 256, tx: 42 };
+        let id = Id256::from(rune_id);
+
+        assert_eq!(id.try_into(), Ok(rune_id));
+    }
+}


### PR DESCRIPTION
For convinience of use I also add implemenation of `From` and `TryFrom` traits for RuneId <--> Id256 conversion, but as the `ordinals` dependency is quite heave, I hide them behind a non-default `runes` feature.

# Issue ticket

Issue ticket link: https://infinityswap.atlassian.net/browse/EPROD-832

## Checklist before requesting a review

### Code conventions

- [x] I have performed a self-review of my code
- [x] Every new function is documented
- [x] Object names are auto explicative

### Security

- [x] The PR does not break APIs backward compatibility
- [x] The PR does not break the stable storage backward compatibility

### Testing

- [x] Every function is properly unit tested
- [ ] I have added integration tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] IC endpoints are always tested through the `canister_call!` macro
