### PR TITLE
[EPROD-852] Remove bft bridge initialization api + eth_gasPrice method in EthJsonRpcClient

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,8 @@ ethereum-types = "0.14"
 ethers-core = "2.0"
 futures = { version = "0.3", default-features = false }
 hex = "0.4"
+# Newer version 0.13.3 breakes backward compatibility. Add this temporary fix until pocket-ic or ic-cdk crates are fixed.
+ic-cdk = "=0.13.2"
 ic-canister = { git = "https://github.com/bitfinity-network/canister-sdk", package = "ic-canister", tag = "v0.16.x" }
 ic-canister-client = { git = "https://github.com/bitfinity-network/canister-sdk", package = "ic-canister-client", tag = "v0.16.x" }
 ic-exports = { git = "https://github.com/bitfinity-network/canister-sdk", package = "ic-exports", tag = "v0.16.x" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ homepage = "https://github.com/bitfinity-network/bitfinity-evm-sdk"
 include = ["src/**/*", "LICENSE", "README.md"]
 license = "MIT"
 repository = "https://github.com/bitfinity-network/bitfinity-evm-sdk"
-version = "0.18.0"
+version = "0.19.0"
 
 [workspace.dependencies]
 alloy-primitives = { version = "0.7", default-feures = false }

--- a/src/did/src/evm_reset_state.rs
+++ b/src/did/src/evm_reset_state.rs
@@ -3,12 +3,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::{AccountInfoMap, Block, H256};
 
-
 /// Describes the state of the EVM reset process.
-#[derive(
-    Debug, Serialize, Deserialize, CandidType
-)]
- pub enum EvmResetState {
+#[derive(Debug, Serialize, Deserialize, CandidType)]
+pub enum EvmResetState {
     /// Start of the reset process.
     /// It deletes all the accounts, storage, Transactions and everything else.
     Start,
@@ -17,5 +14,5 @@ use crate::{AccountInfoMap, Block, H256};
     /// End of the reset process.
     /// It sets the state to the given block.
     /// If the block state hash is not equal to the current state hash, it will fail.
-    End(Block<H256>)
- }
+    End(Block<H256>),
+}

--- a/src/ethereum-json-rpc-client/src/lib.rs
+++ b/src/ethereum-json-rpc-client/src/lib.rs
@@ -24,6 +24,7 @@ pub mod http_outcall;
 
 const ETH_CHAIN_ID_METHOD: &str = "eth_chainId";
 const ETH_GET_BALANCE_METHOD: &str = "eth_getBalance";
+const ETH_GAS_PRICE_METHOD: &str = "eth_gasPrice";
 const ETH_GET_CODE_METHOD: &str = "eth_getCode";
 const ETH_GET_TRANSACTION_COUNT_METHOD: &str = "eth_getTransactionCount";
 const ETH_GET_BLOCK_BY_NUMBER_METHOD: &str = "eth_getBlockByNumber";
@@ -161,6 +162,16 @@ impl<C: Client> EthJsonRpcClient<C> {
             ETH_GET_BALANCE_METHOD.to_string(),
             make_params_array!(address, block),
             Id::Str(ETH_GET_BALANCE_METHOD.to_string()),
+        )
+        .await
+    }
+
+    /// Returns the gas price
+    pub async fn gas_price(&self) -> anyhow::Result<U256> {
+        self.single_request(
+            ETH_GAS_PRICE_METHOD.to_string(),
+            make_params_array!(),
+            Id::Str(ETH_GAS_PRICE_METHOD.to_string()),
         )
         .await
     }

--- a/src/ethereum-json-rpc-client/tests/reqwest/mod.rs
+++ b/src/ethereum-json-rpc-client/tests/reqwest/mod.rs
@@ -36,13 +36,9 @@ async fn should_get_balance() {
     assert_eq!(result, 1409174700000000000u64.into());
 }
 
-
 #[tokio::test]
 async fn should_get_gas_price() {
-    let price = reqwest_client()
-        .gas_price()
-        .await
-        .unwrap();
+    let price = reqwest_client().gas_price().await.unwrap();
     assert!(price > U256::zero());
 }
 

--- a/src/ethereum-json-rpc-client/tests/reqwest/mod.rs
+++ b/src/ethereum-json-rpc-client/tests/reqwest/mod.rs
@@ -1,7 +1,7 @@
 use ethereum_json_rpc_client::reqwest::ReqwestClient;
 use ethereum_json_rpc_client::{EthGetLogsParams, EthJsonRpcClient};
 use ethers_core::abi::{Function, Param, ParamType, StateMutability, Token};
-use ethers_core::types::{BlockNumber, Log, TransactionRequest, H160, H256};
+use ethers_core::types::{BlockNumber, Log, TransactionRequest, H160, H256, U256};
 
 const ETHEREUM_JSON_API_URL: &str = "https://cloudflare-eth.com/";
 const MAX_BATCH_SIZE: usize = 5;
@@ -34,6 +34,16 @@ async fn should_get_balance() {
         .await
         .unwrap();
     assert_eq!(result, 1409174700000000000u64.into());
+}
+
+
+#[tokio::test]
+async fn should_get_gas_price() {
+    let price = reqwest_client()
+        .gas_price()
+        .await
+        .unwrap();
+    assert!(price > U256::zero());
 }
 
 #[tokio::test]

--- a/src/evm-canister-client/src/client.rs
+++ b/src/evm-canister-client/src/client.rs
@@ -7,8 +7,8 @@ use did::permission::{Permission, PermissionList};
 use did::state::{BasicAccount, FullStorageValue, Indices, StateUpdateAction};
 use did::transaction::StorableExecutionResult;
 use did::{
-    Block, BlockNumber, Bytes, EstimateGasRequest, Transaction, TransactionReceipt,
-    H160, H256, U256, U64,
+    Block, BlockNumber, Bytes, EstimateGasRequest, Transaction, TransactionReceipt, H160, H256,
+    U256, U64,
 };
 use ic_canister_client::{CanisterClient, CanisterClientResult};
 pub use ic_log::writer::{Log, Logs};
@@ -814,7 +814,10 @@ impl<C: CanisterClient> EvmCanisterClient<C> {
     }
 
     /// Resets the state of the EVM canister.
-    pub async fn admin_reset_state(&self, state: EvmResetState) -> CanisterClientResult<Result<()>> {
+    pub async fn admin_reset_state(
+        &self,
+        state: EvmResetState,
+    ) -> CanisterClientResult<Result<()>> {
         self.client.update("admin_reset_state", (state,)).await
     }
 

--- a/src/minter-client/src/lib.rs
+++ b/src/minter-client/src/lib.rs
@@ -72,17 +72,6 @@ impl<C: CanisterClient> MinterCanisterClient<C> {
         self.client.update("get_bft_bridge_contract", ()).await
     }
 
-    /// Registers BftBridge contract for EVM canister.
-    /// This method is available for canister owner only.
-    pub async fn register_evmc_bft_bridge(
-        &self,
-        bft_bridge_address: H160,
-    ) -> CanisterClientResult<McResult<()>> {
-        self.client
-            .update("register_evmc_bft_bridge", (bft_bridge_address,))
-            .await
-    }
-
     /// Creates ERC-20 mint order for ICRC-2 tokens burning and sends it to the BFTBridge.
     /// Returns operation id.
     pub async fn burn_icrc2(&self, reason: Icrc2Burn) -> CanisterClientResult<McResult<u32>> {


### PR DESCRIPTION
# Issue ticket

Issue ticket link:
https://infinityswap.atlassian.net/browse/EPROD-852

## Checklist before requesting a review

### Code conventions

- [X] I have performed a self-review of my code
- [X] Every new function is documented
- [X] Object names are auto explicative

### Security

- [X] The PR does not break APIs backward compatibility
- [X] The PR does not break the stable storage backward compatibility

### Testing

- [X] Every function is properly unit tested
- [X] I have added integration tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] IC endpoints are always tested through the `canister_call!` macro
