### PR TITLE
fix wrong reset endpoint name

### DIFF
--- a/src/evm-canister-client/src/client.rs
+++ b/src/evm-canister-client/src/client.rs
@@ -701,11 +701,11 @@ impl<C: CanisterClient> EvmCanisterClient<C> {
 
     /// Manages the reset state of the EVM.
     /// This endpoint is for initializing the EVM state or for recovering from a corrupted state.
-    pub async fn admin_reset_state(
+    pub async fn reset_state(
         &self,
         state: EvmResetState,
     ) -> CanisterClientResult<Result<()>> {
-        self.client.update("admin_reset_state", (state,)).await
+        self.client.update("reset_state", (state,)).await
     }
 
     /// Disable/Enable the inspect message


### PR DESCRIPTION
# Issue ticket

Issue ticket link: <>

## Checklist before requesting a review

### Code conventions

- [ ] I have performed a self-review of my code
- [ ] Every new function is documented
- [ ] Object names are auto explicative

### Security

- [ ] The PR does not break APIs backward compatibility
- [ ] The PR does not break the stable storage backward compatibility

### Testing

- [ ] Every function is properly unit tested
- [ ] I have added integration tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] IC endpoints are always tested through the `canister_call!` macro
