### PR TITLE
Fix cycles check in http_outcall client

### DIFF
--- a/src/ethereum-json-rpc-client/src/http_outcall.rs
+++ b/src/ethereum-json-rpc-client/src/http_outcall.rs
@@ -84,9 +84,9 @@ impl Client for HttpOutcallClient {
 
             let cost = http_request_required_cycles(&request);
 
-            let cycles_available = call::msg_cycles_available128();
+            let cycles_available = ic_exports::ic_cdk::api::canister_balance128();
             if cycles_available < cost {
-                anyhow::bail!("Too few cycles, expected: {cost}, received: {cycles_available}");
+                anyhow::bail!("Too few cycles, expected: {cost}, available: {cycles_available}");
             }
 
             let http_response = http_request::http_request(request, cost)

--- a/src/ethereum-json-rpc-client/src/http_outcall.rs
+++ b/src/ethereum-json-rpc-client/src/http_outcall.rs
@@ -2,7 +2,6 @@ use std::future::Future;
 use std::pin::Pin;
 
 use anyhow::Context;
-use ic_exports::ic_cdk::api::call;
 use ic_exports::ic_cdk::api::management_canister::http_request::{
     self, CanisterHttpRequestArgument, HttpHeader, HttpMethod, TransformContext,
 };


### PR DESCRIPTION
This PR fixes available cycles check when performing HTTP outcalls with `HttpOutcallClient`.

Before the fix, the code checked if the initiator of the current update call provided enough cycles to perform the outcall. But this check actually doesn't make sense because we never call the `accept_cycles` method, so even if the cycles are provided, they are not transferred to the canister. This is also not an appropriate place to do so, because the call can be initiated by the canister itself through the scheduler, so it's not up to the client to decide whether the operation must be paid by the caller or by the canister itself.

Instead, we now check if the canister itself has enough cycles to perform the call. If not, we bail early to prevent unnecessary consensus stage on the async call. It is up to the calling code to receive payment for the call if necessary.

# Issue ticket

Issue ticket link: https://infinityswap.atlassian.net/browse/EPROD-1034

## Checklist before requesting a review

### Code conventions

- [x] I have performed a self-review of my code
- [x] Every new function is documented
- [x] Object names are auto explicative

### Security

- [x] The PR does not break APIs backward compatibility
- [x] The PR does not break the stable storage backward compatibility

### Testing

- [x] Every function is properly unit tested
- [x] I have added integration tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] IC endpoints are always tested through the `canister_call!` macro
