### PR TITLE
Add response transformation for HttpOutcallClient

### DIFF
--- a/src/ethereum-json-rpc-client/Cargo.toml
+++ b/src/ethereum-json-rpc-client/Cargo.toml
@@ -16,6 +16,9 @@ pocket-ic-tests-client = [
 ]
 reqwest = ["dep:reqwest"]
 http-outcall = ["dep:url"]
+# Adds an API method `sanitize_http_response` to the canister and `HttpOutcallClient::new_sanitized` method to use it.
+# We feature-gate it because it changes the API of the canister which is not always necessary.
+sanitize-http-outcall = []
 
 [dependencies]
 anyhow = { workspace = true }

--- a/src/ethereum-json-rpc-client/src/http_outcall.rs
+++ b/src/ethereum-json-rpc-client/src/http_outcall.rs
@@ -2,30 +2,82 @@ use std::future::Future;
 use std::pin::Pin;
 
 use anyhow::Context;
-use ic_exports::ic_cdk::api::management_canister::http_request::{
-    self, CanisterHttpRequestArgument, HttpHeader, HttpMethod, TransformContext,
-};
+use ic_exports::ic_cdk;
+use ic_cdk::api::management_canister::http_request::{self, CanisterHttpRequestArgument, HttpHeader, HttpMethod, TransformContext};
+#[cfg(feature = "sanitize-http-outcall")]
+use ic_cdk::api::management_canister::http_request::{TransformArgs, HttpResponse};
 use jsonrpc_core::Request;
+
 
 use crate::Client;
 
-/// Http outcall client implementation.
+/// EVM client that uses HTTPS Outcalls to communicate with EVM.
+///
+/// This client can be used to connect to external EVM RPC services, but due to IC HTTPS Outcall
+/// protocol interface, there are a few limitations that these services must comply with:
+/// * Identical requests must produce identical response bodies.
+/// * If some of the response headers may vary for different requests, response transformation must
+///   be used (see [HttpOutcallClient::new_with_transform]).
+/// * The service must not use redirects or any other form of indirection. All valid RPC requests
+///   must be answered with `200 OK` status code and a valid RPC response.
+/// * The service must support batched RPC requests.
+///
+/// Note that when a canister is run in replicated mode (e.g. on IC mainneet), every call to
+/// [`HttpClient::send_rpc_request`] will result in multiple concurrent identical HTTP POST requests
+/// to the target EVM.
+///
+/// For more information about how IC HTTPS Outcalls work see [IC documentation](https://internetcomputer.org/docs/current/tutorials/developer-journey/level-3/3.2-https-outcalls/)
 #[derive(Debug, Clone)]
 pub struct HttpOutcallClient {
     url: String,
     max_response_bytes: Option<u64>,
+    #[allow(dead_code)]
+    transform_context: Option<TransformContext>,
 }
 
 impl HttpOutcallClient {
     /// Creates a new client.
     ///
     /// # Arguments
-    /// * `url` - The url of the canister.
-    ///
+    /// * `url` - the url of the RPC service to connect to.
     pub fn new(url: String) -> Self {
         Self {
             url,
             max_response_bytes: None,
+            transform_context: None,
+        }
+    }
+
+    /// Creates a new client.
+    ///
+    /// You can use [`new_sanitized`] method to use default transform context. (Available with
+    /// Cargo feature `sanitize-http-outcall`)
+    ///
+    /// # Arguments
+    /// * `url` - the url of the RPC service to connect to.
+    /// * `transform_context` - method to use to sanitize HTTP response
+    pub fn new_with_transform(url: String, transform_context: TransformContext) -> Self {
+        Self {
+            url,
+            max_response_bytes: None,
+            transform_context: Some(transform_context),
+        }
+    }
+
+    /// Creates a new client with default sanitize method.
+    ///
+    /// The default sanitize drops most of HTTP headers that may prevent consensus on the response.
+    ///
+    /// Only available with Cargo feature `sanitize-http-outcall`.
+    ///
+    /// # Arguments
+    /// * `url` - the url of the RPC service to connect to.
+    #[cfg(feature = "sanitize-http-outcall")]
+    pub fn new_sanitized(url: String) -> Self {
+        Self {
+            url,
+            max_response_bytes: None,
+            transform_context: Some(TransformContext::from_name("sanitize_http_response".into(), vec![])),
         }
     }
 
@@ -40,6 +92,16 @@ impl HttpOutcallClient {
     pub fn set_max_response_bytes(&mut self, max_response_bytes: Option<u64>) {
         self.max_response_bytes = max_response_bytes;
     }
+}
+
+#[cfg(feature = "sanitize-http-outcall")]
+#[ic_cdk::query]
+fn sanitize_http_response(raw_response: TransformArgs) -> HttpResponse {
+    const USE_HEADERS: &[&str] = &["content-encoding", "content-length", "content-type", "host"];
+    let TransformArgs { mut response, .. } = raw_response;
+    response.headers.retain(|header| USE_HEADERS.iter().any(|v| v == &header.name.to_lowercase()));
+
+    response
 }
 
 impl Client for HttpOutcallClient {
@@ -71,6 +133,8 @@ impl Client for HttpOutcallClient {
                     value: "application/json".to_string(),
                 },
             ];
+            log::trace!("Making http request to {url} with headers: {headers:?}");
+            log::trace!("Request body is: {}", String::from_utf8_lossy(&body));
 
             let request = CanisterHttpRequestArgument {
                 url,
@@ -78,7 +142,7 @@ impl Client for HttpOutcallClient {
                 method: HttpMethod::POST,
                 headers,
                 body: Some(body),
-                transform: Some(TransformContext::from_name("transform".to_string(), vec![])),
+                transform: None,
             };
 
             let cost = http_request_required_cycles(&request);
@@ -95,10 +159,12 @@ impl Client for HttpOutcallClient {
                     anyhow::format_err!(format!("RejectionCode: {r:?}, Error: {m}"))
                 })?;
 
-            let response = serde_json::from_slice(&http_response.body)
-                .context("failed to deserialize RPC request")?;
+            log::trace!("CanisterClient - Response from http_outcall'. Response: {} {:?}. Body: {}", http_response.status, http_response.headers, String::from_utf8_lossy(&http_response.body));
 
-            log::trace!("CanisterClient - Response from http_outcall'. Response : {response:?}");
+            let response = serde_json::from_slice(&http_response.body)
+                .context("failed to deserialize RPC response")?;
+
+            log::trace!("CanisterClient - Deserialized response: {response:?}");
 
             Ok(response)
         })
@@ -120,4 +186,34 @@ pub fn http_request_required_cycles(arg: &CanisterHttpRequestArgument) -> u128 {
         + (arg_raw.len() as u128 + "http_request".len() as u128) * 400
         + max_response_bytes * 800)
         * 13
+}
+
+#[cfg(test)]
+mod tests {
+    use candid::Nat;
+    use super::*;
+
+    #[cfg(feature = "sanitize-http-outcall")]
+    #[test]
+    fn sanitize_http_response_removes_extra_headers() {
+        let transform_args = TransformArgs {
+            response: HttpResponse {
+                status: 200u128.into(),
+                headers: vec![
+                    HttpHeader { name: "content-type".to_string(), value: "application/json".to_string() },
+                    HttpHeader { name: "content-length".to_string(), value: "42".to_string() },
+                    HttpHeader { name: "content-encoding".to_string(), value: "gzip".to_string() },
+                    HttpHeader { name: "date".to_string(), value: "Fri, 11 Oct 2024 10:25:08 GMT".to_string() },
+                ],
+                body: vec![],
+            },
+            context: vec![],
+        };
+
+        let sanitized: HttpResponse = sanitize_http_response(transform_args);
+        assert_eq!(sanitized.headers.len(), 3);
+        assert_eq!(sanitized.status, Nat::from(200u128));
+        assert!(sanitized.headers.iter().any(|header| header.name == "content-type"));
+        assert!(!sanitized.headers.iter().any(|header| header.name == "date"));
+    }
 }


### PR DESCRIPTION
Without response transformation http outcalls will not work in most cases when deployed in replecated environment. So this PR adds response transformation for HttpOutcallClient.

# Issue ticket

Issue ticket link: https://infinityswap.atlassian.net/browse/EPROD-1034

## Checklist before requesting a review

### Code conventions

- [x] I have performed a self-review of my code
- [x] Every new function is documented
- [x] Object names are auto explicative

### Security

- [x] The PR does not break APIs backward compatibility
- [x] The PR does not break the stable storage backward compatibility

### Testing

- [x] Every function is properly unit tested
- [x] I have added integration tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] IC endpoints are always tested through the `canister_call!` macro
