### PR TITLE
Add did struct for `revert_to_block` method

### DIFF
--- a/src/did/src/lib.rs
+++ b/src/did/src/lib.rs
@@ -25,6 +25,7 @@ pub mod integer;
 pub mod keccak;
 pub mod logs;
 pub mod permission;
+pub mod revert_blocks;
 pub mod state;
 pub mod transaction;
 

--- a/src/did/src/revert_blocks.rs
+++ b/src/did/src/revert_blocks.rs
@@ -1,0 +1,39 @@
+use std::fmt::Display;
+
+use candid::CandidType;
+use ethers_core::utils::hex::ToHexExt;
+use serde::{Deserialize, Serialize};
+
+use crate::H256;
+
+/// Arguments for `revert_to_block` method of EVM canister
+///
+/// The target block is speicified by the `to_block_number` field and the other fields are used to
+/// verify that the caller actually knows what they are doing.
+#[derive(Debug, Serialize, Deserialize, CandidType, PartialEq, Eq, Clone)]
+pub struct RevertToBlockArgs {
+    /// Current latest block number.
+    pub from_block_number: u64,
+
+    /// Hash of the latest block.
+    pub from_block_hash: H256,
+
+    /// Block number to revert to.
+    pub to_block_number: u64,
+
+    /// Hash of the block to revert to.
+    pub to_block_hash: H256,
+}
+
+impl Display for RevertToBlockArgs {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{{from_block_number: {}, from_block_hash: {}, to_block_number: {}, to_block_hash: {}}}",
+            self.from_block_number,
+            self.from_block_hash.0.encode_hex_with_prefix(),
+            self.to_block_number,
+            self.to_block_hash.0.encode_hex_with_prefix()
+        )
+    }
+}

--- a/src/evm-canister-client/src/client.rs
+++ b/src/evm-canister-client/src/client.rs
@@ -4,6 +4,7 @@ use did::build::BuildData;
 use did::error::Result;
 use did::evm_reset_state::EvmResetState;
 use did::permission::{Permission, PermissionList};
+use did::revert_blocks::RevertToBlockArgs;
 use did::state::BasicAccount;
 use did::transaction::StorableExecutionResult;
 use did::{
@@ -823,5 +824,21 @@ impl<C: CanisterClient> EvmCanisterClient<C> {
         block: Block<Transaction>,
     ) -> CanisterClientResult<Result<()>> {
         self.client.update("append_block", (block,)).await
+    }
+
+    /// Drops all blocks up to the `block_number`.
+    ///
+    /// Only the blocks for which state history is preserved can be reverted.
+    ///
+    /// # Errors
+    ///
+    /// * [`EvmError::BlockDoesNotExist`] if given block number is higher than the tip of the
+    ///   chain.
+    /// * [`EvmError::NoHistoryDataForBlock`] if trying to revert to a block for which no history
+    ///   is preserved.
+    /// * [`EvmError::BadRequest`] if given arguments do not match actual values expected by the
+    ///   EVM.
+    pub async fn revert_to_block(&self, args: RevertToBlockArgs) -> CanisterClientResult<Result<()>> {
+        self.client.update("revert_to_block", (args,)).await
     }
 }

--- a/src/evm-canister-client/src/client.rs
+++ b/src/evm-canister-client/src/client.rs
@@ -838,7 +838,10 @@ impl<C: CanisterClient> EvmCanisterClient<C> {
     ///   is preserved.
     /// * [`EvmError::BadRequest`] if given arguments do not match actual values expected by the
     ///   EVM.
-    pub async fn revert_to_block(&self, args: RevertToBlockArgs) -> CanisterClientResult<Result<()>> {
+    pub async fn revert_to_block(
+        &self,
+        args: RevertToBlockArgs,
+    ) -> CanisterClientResult<Result<()>> {
         self.client.update("revert_to_block", (args,)).await
     }
 }


### PR DESCRIPTION
# Issue ticket

Issue ticket link: [EPROD-1076](https://infinityswap.atlassian.net/browse/EPROD-1076)

## Checklist before requesting a review

### Code conventions

- [x] I have performed a self-review of my code
- [x] Every new function is documented
- [x] Object names are auto explicative

### Security

- [x] The PR does not break APIs backward compatibility
- [x] The PR does not break the stable storage backward compatibility

### Testing

- [x] Every function is properly unit tested
- [x] I have added integration tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] IC endpoints are always tested through the `canister_call!` macro


[EPROD-1076]: https://infinityswap.atlassian.net/browse/EPROD-1076?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ