### PR TITLE
EPROD-1117 removed Indices

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ homepage = "https://github.com/bitfinity-network/bitfinity-evm-sdk"
 include = ["src/**/*", "LICENSE", "README.md"]
 license = "MIT"
 repository = "https://github.com/bitfinity-network/bitfinity-evm-sdk"
-version = "0.41.0"
+version = "0.42.0"
 
 [workspace.dependencies]
 did = { path = "src/did" }

--- a/src/did/src/state.rs
+++ b/src/did/src/state.rs
@@ -4,7 +4,7 @@ use candid::CandidType;
 use ic_stable_structures::{Bound, Storable};
 use serde::{Deserialize, Serialize};
 
-use crate::codec::{self, ByteChunkReader};
+use crate::codec;
 use crate::U256;
 
 /// Describes basic state of an EVM account.
@@ -14,43 +14,6 @@ pub struct BasicAccount {
     pub balance: U256,
     /// Account nonce.
     pub nonce: U256,
-}
-
-/// StableDBStorage indices information
-#[derive(Debug, Clone, Serialize, CandidType, Deserialize, Eq, PartialEq)]
-pub struct Indices {
-    /// Index of the current block
-    pub pending_block: u64,
-    /// Number of block to keep history
-    pub history_size: u64,
-}
-
-impl Indices {
-    const STORABLE_BYTE_SIZE: usize = std::mem::size_of::<u64>() * 2;
-}
-
-impl Storable for Indices {
-    fn to_bytes(&self) -> std::borrow::Cow<[u8]> {
-        let mut buf = Vec::with_capacity(Self::STORABLE_BYTE_SIZE);
-        buf.extend_from_slice(&self.pending_block.to_be_bytes());
-        buf.extend_from_slice(&self.history_size.to_be_bytes());
-        buf.into()
-    }
-
-    fn from_bytes(bytes: Cow<'_, [u8]>) -> Self {
-        let mut reader = ByteChunkReader::new(&bytes);
-        let pending_block = u64::from_be_bytes(*reader.read_slice());
-        let history_size = u64::from_be_bytes(*reader.read_slice());
-        Self {
-            pending_block,
-            history_size,
-        }
-    }
-
-    const BOUND: Bound = Bound::Bounded {
-        max_size: Self::STORABLE_BYTE_SIZE as _,
-        is_fixed_size: true,
-    };
 }
 
 /// Full information about entry
@@ -93,19 +56,6 @@ mod test {
         let deserialized = Decode!(serialized.as_slice(), BasicAccount).unwrap();
 
         assert_eq!(account, deserialized);
-    }
-
-    #[test]
-    fn test_storable_indices() {
-        let indices = Indices {
-            pending_block: 1,
-            history_size: 2,
-        };
-
-        let serialized = indices.to_bytes();
-        let deserialized = Indices::from_bytes(serialized);
-
-        assert_eq!(indices, deserialized);
     }
 
     #[test]


### PR DESCRIPTION
Indices was unused by the public endpoint and it doesn't make sense to make it public.

Ci is broken due to not up-to-date testnet