### PR TITLE
Add FromStr impl for hash structs

### DIFF
--- a/src/did/src/hash.rs
+++ b/src/did/src/hash.rs
@@ -1,6 +1,7 @@
 use std::borrow::Cow;
 use std::fmt;
 use std::rc::Rc;
+use std::str::FromStr;
 
 use alloy::hex::FromHexError;
 use candid::types::{Type, TypeInner};
@@ -74,6 +75,14 @@ impl H64 {
     }
 }
 
+impl FromStr for H64 {
+    type Err = FromHexError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::from_hex_str(s)
+    }
+}
+
 impl H160 {
     pub const BYTE_SIZE: usize = 20;
 
@@ -100,6 +109,14 @@ impl H160 {
     }
 }
 
+impl FromStr for H160 {
+    type Err = FromHexError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::from_hex_str(s)
+    }
+}
+
 impl H256 {
     pub const BYTE_SIZE: usize = 32;
 
@@ -121,6 +138,14 @@ impl H256 {
 
     pub const fn zero() -> Self {
         Self(alloy::primitives::B256::ZERO)
+    }
+}
+
+impl FromStr for H256 {
+    type Err = FromHexError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::from_hex_str(s)
     }
 }
 


### PR DESCRIPTION
This will allow us to use the hash types as clap arguments using clap validation etc.

# Issue ticket

Issue ticket link: <>

## Checklist before requesting a review

### Code conventions

- [ ] I have performed a self-review of my code
- [ ] Every new function is documented
- [ ] Object names are auto explicative

### Security

- [ ] The PR does not break APIs backward compatibility
- [ ] The PR does not break the stable storage backward compatibility

### Testing

- [ ] Every function is properly unit tested
- [ ] I have added integration tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] IC endpoints are always tested through the `canister_call!` macro
