### PR TITLE
EPROD-1155 H160, H256, H64, U64, U256 and Bloom aren't serialized correctly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ alloy = { version = "0.9", features = [
 anyhow = "1.0"
 async-trait = "0.1"
 bincode = "1.3"
-bytes = "1.7"
+bytes = "1"
 candid = "0.10"
 clap = { version = "4", features = ["derive", "env"] }
 chrono = { version = "0.4", default-features = false }

--- a/src/did/src/hash.rs
+++ b/src/did/src/hash.rs
@@ -8,10 +8,8 @@ use candid::types::{Type, TypeInner};
 use candid::CandidType;
 use derive_more::Display;
 use ic_stable_structures::{Bound, Bounded, Storable};
-use serde::Serialize;
 
-#[derive(Debug, Default, Clone, PartialOrd, Ord, Eq, PartialEq, Serialize, Display, Hash)]
-#[serde(transparent)]
+#[derive(Debug, Default, Clone, PartialOrd, Ord, Eq, PartialEq, Display, Hash)]
 pub struct Hash<T>(pub T);
 
 ///Fixed-size uninterpreted hash type with 8 bytes (64 bits) size.
@@ -28,6 +26,24 @@ pub fn from_hex_str<const SIZE: usize>(mut s: &str) -> Result<[u8; SIZE], FromHe
 
     let mut result = [0u8; SIZE];
     alloy::hex::decode_to_slice(s, &mut result).and(Ok(result))
+}
+
+impl serde::Serialize for H64 {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        s.serialize_str(&self.to_hex_str())
+    }
+}
+
+impl serde::Serialize for H160 {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        s.serialize_str(&self.to_hex_str())
+    }
+}
+
+impl serde::Serialize for H256 {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        s.serialize_str(&self.to_hex_str())
+    }
 }
 
 impl<'de> serde::Deserialize<'de> for H64 {
@@ -630,5 +646,36 @@ mod tests {
         let decoded_value: H256 = serde_json::from_value(encoded_primitive).unwrap();
 
         assert_eq!(value, decoded_value);
+    }
+
+    #[test]
+    fn test_should_bincode_h160() {
+        let value = H160::from_hex_str("0xbf380c52c18d5ead99ea719b6fcfbba551df2f7f")
+            .expect("valid address");
+
+        let encoded = bincode::serialize(&value).expect("serialization failed");
+        let decoded: H160 = bincode::deserialize(&encoded).expect("deserialization failed");
+
+        assert_eq!(value, decoded);
+    }
+
+    #[test]
+    fn test_should_bincode_h64() {
+        let value = H64::new(alloy::primitives::B64::random());
+
+        let encoded = bincode::serialize(&value).expect("serialization failed");
+        let decoded: H64 = bincode::deserialize(&encoded).expect("deserialization failed");
+
+        assert_eq!(value, decoded);
+    }
+
+    #[test]
+    fn test_should_bincode_h256() {
+        let value = H256::new(alloy::primitives::B256::random());
+
+        let encoded = bincode::serialize(&value).expect("serialization failed");
+        let decoded: H256 = bincode::deserialize(&encoded).expect("deserialization failed");
+
+        assert_eq!(value, decoded);
     }
 }

--- a/src/did/src/integer.rs
+++ b/src/did/src/integer.rs
@@ -9,17 +9,24 @@ use candid::{CandidType, Nat};
 use derive_more::{From, Into};
 use ic_stable_structures::{Bound, Bounded, Storable};
 use num::BigUint;
-use serde::Serialize;
 
-#[derive(Debug, Default, Clone, Eq, PartialEq, PartialOrd, Ord, Serialize, Hash, From, Into)]
-#[serde(transparent)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, PartialOrd, Ord, Hash, From, Into)]
 pub struct U256(pub alloy::primitives::U256);
 
-#[derive(
-    Debug, Default, Copy, Clone, Eq, PartialEq, PartialOrd, Ord, Serialize, Hash, From, Into,
-)]
-#[serde(transparent)]
+#[derive(Debug, Default, Copy, Clone, Eq, PartialEq, PartialOrd, Ord, Hash, From, Into)]
 pub struct U64(pub alloy::primitives::U64);
+
+impl serde::Serialize for U64 {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        s.serialize_str(&self.to_hex_str())
+    }
+}
+
+impl serde::Serialize for U256 {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        s.serialize_str(&self.to_hex_str())
+    }
+}
 
 impl<'de> serde::Deserialize<'de> for U64 {
     fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
@@ -673,5 +680,21 @@ mod tests {
         let decoded_value: U64 = serde_json::from_value(encoded_primitive).unwrap();
 
         assert_eq!(value, decoded_value);
+    }
+
+    #[test]
+    fn test_should_serialize_bincode_u256() {
+        let value = U256::from(rand::random::<u128>());
+        let encoded = bincode::serialize(&value).unwrap();
+        let decoded: U256 = bincode::deserialize(&encoded).unwrap();
+        assert_eq!(value, decoded);
+    }
+
+    #[test]
+    fn test_should_serialize_bincode_u64() {
+        let value = U64::from(rand::random::<u64>());
+        let encoded = bincode::serialize(&value).unwrap();
+        let decoded: U64 = bincode::deserialize(&encoded).unwrap();
+        assert_eq!(value, decoded);
     }
 }

--- a/src/did/src/transaction.rs
+++ b/src/did/src/transaction.rs
@@ -894,8 +894,14 @@ impl Storable for StorableExecutionResult {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Bloom(pub alloy::primitives::Bloom);
+
+impl serde::Serialize for Bloom {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        s.serialize_str(&self.to_hex_str())
+    }
+}
 
 impl<'de> serde::Deserialize<'de> for Bloom {
     fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {


### PR DESCRIPTION
Serialization of H64, H160 and H256 is broken, because the function that deserialize works differently from the one that is serializing the data,
causing for instance, bincode to fail when deserializing a previously serialized H160 with serde.

This is causing bitfusion-sdk to fail to put Operations into the ic-task-scheduler.

I haven't bumped the version since this shouldn't be a breaking change on the evm. If evm serialized the data, it would have not worked so far.
